### PR TITLE
Expand reference to the sast-snyk-check task

### DIFF
--- a/.tekton/vector-pull-request.yaml
+++ b/.tekton/vector-pull-request.yaml
@@ -429,7 +429,7 @@ spec:
                   cp -r "$(workspaces.source.path)/cachi2" /tmp/
                   chmod -R go+rwX /tmp/cachi2
                   VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-                  sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\
+                  sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\
                     |i' "$dockerfile_path"
                   echo "Prefetched content will be made available"
 
@@ -767,15 +767,6 @@ spec:
       - name: sast-snyk-check
         runAfter:
           - clone-repository
-        taskRef:
-          params:
-            - name: name
-              value: sast-snyk-check
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:242acc527a06a11fac9dd6524467f62f3a086c186c5f885973e5780a04d4289c
-            - name: kind
-              value: task
-          resolver: bundles
         when:
           - input: $(params.skip-checks)
             operator: in
@@ -784,6 +775,82 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        taskSpec:
+          description: Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
+          params:
+            - default: snyk-secret
+              description: Name of secret which contains Snyk token.
+              name: SNYK_SECRET
+            - default: --all-projects --exclude=test*,vendor,deps
+              description: Append arguments.
+              name: ARGS
+              type: string
+          results:
+            - description: Tekton task test output.
+              name: TEST_OUTPUT
+          steps:
+            - env:
+                - name: SNYK_SECRET
+                  value: $(params.SNYK_SECRET)
+                - name: ARGS
+                  value: $(params.ARGS)
+              image: quay.io/redhat-appstudio/konflux-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea
+              name: sast-snyk-check
+              script: |
+                #!/usr/bin/env bash
+                set -euo pipefail
+                . /utils.sh
+                trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+                SNYK_TOKEN_PATH="/etc/secrets/snyk_token"
+
+                if [ -f "${SNYK_TOKEN_PATH}" ] && [ -s "${SNYK_TOKEN_PATH}" ]; then
+                  # SNYK token is provided
+                  SNYK_TOKEN="$(cat ${SNYK_TOKEN_PATH})"
+                  export SNYK_TOKEN
+                else
+                  to_enable_snyk='[here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/)'
+                  note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key "snyk_token" containing the Snyk token by following the steps given ${to_enable_snyk}"
+                  TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
+                  echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+                  exit 0
+                fi
+
+                SNYK_EXIT_CODE=0
+                SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
+                snyk code test $ARGS $SOURCE_CODE_DIR --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?
+                test_not_skipped=0
+                SKIP_MSG="We found 0 supported files"
+                grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?
+
+                if [[ "$SNYK_EXIT_CODE" -eq 0 ]] || [[ "$SNYK_EXIT_CODE" -eq 1 ]]; then
+                  cat sast_snyk_check_out.json
+                  TEST_OUTPUT=
+                  parse_test_output $(context.task.name) sarif sast_snyk_check_out.json  || true
+
+                # When the test is skipped, the "SNYK_EXIT_CODE" is 3 and it can also be 3 in some other situation
+                elif [[ "$test_not_skipped" -eq 0 ]]; then
+                  note="Task $(context.task.name) success: Snyk code test found zero supported files."
+                  ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+                else
+                  echo "sast-snyk-check test failed because of the following issues:"
+                  cat stdout.txt
+                  note="Task $(context.task.name) failed: For details, check Tekton task log."
+                  ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+                fi
+                echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
+              volumeMounts:
+                - mountPath: /etc/secrets
+                  name: snyk-secret
+                  readOnly: true
+              workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+          volumes:
+            - name: snyk-secret
+              secret:
+                optional: true
+                secretName: $(params.SNYK_SECRET)
+          workspaces:
+            - name: workspace
       - name: clamav-scan
         params:
           - name: image-digest


### PR DESCRIPTION
So that we can hack on it.

Done using https://gist.github.com/ralphbean/dbee2755b4077caa4056a46660d2907f

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
